### PR TITLE
Don't mess with users keybindings, partially addresses #63

### DIFF
--- a/realgud/common/key.el
+++ b/realgud/common/key.el
@@ -93,7 +93,6 @@ The variable `realgud-populate-common-fn-keys-function' controls the layout."
   (define-key map "\C-x\C-a\C-q" 'realgud-short-key-mode)
   (if realgud-populate-common-fn-keys-function
       (funcall realgud-populate-common-fn-keys-function map))
-  (realgud-populate-common-fn-keys-standard map)
 )
 
 (defun realgud-populate-src-buffer-map-plain (map)


### PR DESCRIPTION
The below line seems to be wrong, if the user set realgud-populate-common-fn-keys-function to "nil", we really shouldn't call it.