### PR TITLE
Improve eval: run on region if active, and fall back to prompting

### DIFF
--- a/realgud/common/cmds.el
+++ b/realgud/common/cmds.el
@@ -117,17 +117,25 @@ a shortcut for that key."
     )
 
 (defun realgud:cmd-eval(arg)
-    "Exaluate an expression."
+    "Evaluate an expression."
     (interactive "MEval expesssion: ")
     (realgud:cmd-remap arg "eval" "eval %s" "e")
 )
 
 (defun realgud:cmd-eval-region(start end)
+    "Evaluate current region."
     (interactive "r")
     (let ((text (buffer-substring-no-properties start end)))
       (realgud:cmd-remap text "eval" "eval %s" "e")
       )
     )
+
+(defun realgud:cmd-eval-dwim()
+  "Eval the current region if active; otherwise, prompt."
+  (interactive)
+  (call-interactively (if (region-active-p)
+                          #'realgud:cmd-eval-region
+                        #'realgud:cmd-eval)))
 
 (defun realgud:cmd-finish(&optional arg)
     "Run until the completion of the current stack frame.

--- a/realgud/common/menu.el
+++ b/realgud/common/menu.el
@@ -152,9 +152,9 @@ menu. (The common map typically contains function key bindings.)"
 			 ))
 
     (define-key debugger-map [eval]
-      (realgud-menu-item debugger-map "Evaluate Region" 'realgud:cmd-eval-region
+      (realgud-menu-item debugger-map "Evaluate region or string" 'realgud:cmd-eval-dwim
 			 :enable '(realgud-get-process)
-			 :help (documentation 'realgud:cmd-eval-region)
+			 :help (documentation 'realgud:cmd-eval-dwim)
 			 ))
 
     (define-key debugger-map [Recenter]

--- a/realgud/common/shortkey.el
+++ b/realgud/common/shortkey.el
@@ -43,7 +43,7 @@
     (define-key map "9"        'realgud:goto-loc-hist-9)
     (define-key map "b"        'realgud:cmd-break)
     (define-key map "c"        'realgud:cmd-continue)
-    (define-key map "e"        'realgud:cmd-eval-region)
+    (define-key map "e"        'realgud:cmd-eval-dwim)
     (define-key map "U"        'realgud:cmd-until)
     (define-key map [mouse-2]  'realgud:tooltip-eval)
 


### PR DESCRIPTION
Part of #83. Btw, when I lookup the `C-c e` keybinding in realgud:gdb, I see this:

```
C-c e runs the command realgud:cmd-eval (found in
realgud:gdb-short-key-mode-map), which is an interactive Lisp function in
‘realgud/common/cmds.el’.
```

However, I couldn't track down `realgud:gdb-short-key-mode-map` or the code that sets this binding... where is it? (I wanted to add a small comment to it, noting that it could be disabled in a future release)
