### PR TITLE
Manually generate "recursive" autoloads for subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Makefile.in
 elc-stamp
 elc-temp
 script
+/realgud-autoloads.el

--- a/realgud-recursive-autoloads.el
+++ b/realgud-recursive-autoloads.el
@@ -1,0 +1,1300 @@
+;;; realgud-recursive-autoloads.el --- automatically extracted autoloads
+;;
+;;; Code:
+
+
+;;;### (autoloads nil "realgud/common/backtrace-mode" "realgud/common/backtrace-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/backtrace-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/backtrace-mode" '("realgud-backtrace-mode-map" "realgud-backtrace-mode" "realgud:frames-menu")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/backtrack-mode" "realgud/common/backtrack-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/backtrack-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/backtrack-mode" '("realgud-backtrack-set-debugger" "realgud-backtrack-mode" "realgud-backtrack-mode-map" "realgud-backtrack-mode-vars")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/bp" "realgud/common/bp.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/bp.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/bp" '("realgud-bp-")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/bp-image-data" "realgud/common/bp-image-data.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/bp-image-data.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/bp-image-data" '("realgud-bp-disabled-" "realgud-bp-enabled-tiff-data" "realgud-bp-enabled-svg-data" "realgud-bp-enabled-pbm-data" "realgud-bp-xpm-data")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/buffer/backtrace" "realgud/common/buffer/backtrace.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/buffer/backtrace.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/buffer/backtrace" '("realgud-backtrace-" "realgud-goto-" "realgud:backtrace-" "realgud-track-divert-string" "realgud-backtrace?")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/buffer/command" "realgud/common/buffer/command.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/buffer/command.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/buffer/command" '("realgud-cmdbuf-" "realgud:cmdbuf-buffers-describe" "realgud:cmdbuf-info-describe" "realgud-cmdbuf?")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/buffer/helper" "realgud/common/buffer/helper.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/buffer/helper.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/buffer/helper" '("realgud:srcbuf-info-describe" "realgud-get-process" "realgud-get-srcbuf-from-cmdbuf" "realgud-get-cmdbuf-from-srcbuf" "realgud-get-cmdbuf-from-backtrace")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/buffer/info" "realgud/common/buffer/info.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/buffer/info.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/buffer/info" '("realgud:info-mode-hook" "realgud:info-mode" "realgud-backtrace-info")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/buffer/source" "realgud/common/buffer/source.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/buffer/source.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/buffer/source" '("realgud-srcbuf-" "realgud-srcbuf?")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/cmds" "realgud/common/cmds.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/cmds.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/cmds" '("realgud-safe-mode" "realgud:cmd-quit" "realgud:cmd-terminate")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/core" "realgud/common/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/core" '("realgud-" "realgud:")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/custom" "realgud/common/custom.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/custom.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/custom" '("realgud-srcbuf-lock" "realgud-key-prefix")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/eval" "realgud/common/eval.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/eval.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/eval" '("realgud:tooltip-eval" "realgud:eval-process-output")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/file" "realgud/common/file.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/file.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/file" '("realgud-file-remap")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/fringe" "realgud/common/fringe.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/fringe.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/fringe" '("realgud-overlay-" "realgud-fringe-erase-history-arrows" "realgud-fringe-history-set" "realgud-fringe-set-arrow")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/helper" "realgud/common/helper.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/helper.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/helper" '("realgud-" "with-current-buffer-safe" "buffer-killed?" "realgud:debugger-name-transform" "fn-p-to-fn?-alias")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/init" "realgud/common/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/init" '("realgud-line-number-face" "realgud-backtrace-number-face" "realgud-file-name-face")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/key" "realgud/common/key.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/key.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/key" '("realgud-populate-src-buffer-map-plain" "realgud-populate-common-keys" "realgud-populate-common-fn-keys-function" "realgud-populate-common-fn-keys-standard")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/lang" "realgud/common/lang.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/lang.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/lang" '("realgud-suggest-lang-file" "realgud-lang-mode?" "realgud:suggest-file-from-buffer")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/loc" "realgud/common/loc.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/loc.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/loc" '("realgud-loc?" "realgud-loc" "realgud:loc-describe")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/lochist" "realgud/common/lochist.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/lochist.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/lochist" '("realgud-loc-hist-" "realgud-loc-hist")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/menu" "realgud/common/menu.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/menu.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/menu" '("realgud-menu-item" "realgud-populate-debugger-menu")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/regexp" "realgud/common/regexp.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/regexp.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/regexp" '("realgud:regexp-captured-num" "realgud:variable-basename-hash" "realgud-loc-pat" "realgud-pat-hash" "realgud-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/reset" "realgud/common/reset.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/reset.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/reset" '("realgud:reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/run" "realgud/common/run.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/run.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/run" '("realgud:run-debugger")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/send" "realgud/common/send.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/send.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/send" '("realgud:send-" "realgud-send-" "comint-output-filter-orig" "realgud-expand-format" "realgud-command")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/shortkey" "realgud/common/shortkey.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/shortkey.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/shortkey" '("realgud:goto-loc-hist-" "realgud-short-key-" "realgud:shortkey-mode-map" "realgud-get-short-key-mode-map" "realgud-populate-src-buffer-map")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/track" "realgud/common/track.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/track.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/track" '("realgud-goto-line-for-" "realgud-track-" "realgud:goto-" "realgud-short-key-on-tracing?" "realgud:track-set-debugger")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/track-mode" "realgud/common/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/track-mode" '("realgud-track-mode" "realgud:tool-bar-map" "realgud-track-mode-map" "realgud-track-mode-setup" "realgud-track-mode-vars")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/utils" "realgud/common/utils.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/utils.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/utils" '("realgud:strip" "realgud:flatten")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/common/window" "realgud/common/window.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/common/window.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/common/window" '("realgud:window-bt-undisturb-src" "realgud-window-cmd-undisturb-src" "realgud-window-src-undisturb-cmd" "realgud-window-src" "realgud-window-update-position")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/bashdb/bashdb" "realgud/debugger/bashdb/bashdb.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/bashdb/bashdb.el
+
+(autoload 'realgud:bashdb "realgud/debugger/bashdb/bashdb" "\
+Invoke the bashdb shell debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run bash. You will be prompted
+for a command line is one isn't supplied.
+
+OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `bashdb-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/bashdb/bashdb" '("realgud:bashdb-command-name" "bashdb")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/bashdb/core" "realgud/debugger/bashdb/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/bashdb/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/bashdb/core" '("realgud:bashdb-" "bashdb-query-cmdline" "bashdb-parse-cmd-args" "bashdb-suggest-invocation" "bashdb-reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/bashdb/init" "realgud/debugger/bashdb/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/bashdb/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/bashdb/init" '("realgud:bashdb-pat-hash" "realgud:bashdb-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/bashdb/track-mode" "realgud/debugger/bashdb/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/bashdb/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/bashdb/track-mode" '("bashdb-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/gdb/core" "realgud/debugger/gdb/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/gdb/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/gdb/core" '("realgud:gdb-")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/gdb/gdb" "realgud/debugger/gdb/gdb.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/gdb/gdb.el
+
+(autoload 'realgud:gdb "realgud/debugger/gdb/gdb" "\
+Invoke the gdb debugger and start the Emacs user interface.
+
+OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/gdb/gdb" '("realgud:gdb-pid-associate" "realgud:gdb-pid-command-buffer" "realgud:gdb-pid" "realgud:gdb-find-command-buffer" "realgud:gdb-command-name")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/gdb/init" "realgud/debugger/gdb/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/gdb/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/gdb/init" '("realgud:gdb-frame-num-regexp" "realgud:gdb-frame-start-regexp" "realgud:gdb-frame-file-regexp" "realgud:gdb-command-hash" "realgud:gdb-pat-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/gdb/track-mode" "realgud/debugger/gdb/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/gdb/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/gdb/track-mode" '("realgud:gdb-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/gub/core" "realgud/debugger/gub/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/gub/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/gub/core" '("realgud:gub-" "gub-query-cmdline" "gub-parse-cmd-args" "gub-suggest-invocation" "gub-reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/gub/gub" "realgud/debugger/gub/gub.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/gub/gub.el
+
+(autoload 'realgud-gub "realgud/debugger/gub/gub" "\
+Invoke the Go SSA debugger, gub and start the Emacs user interface.
+
+String COMMAND-LINE specifies how to run gub.
+
+Normally command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset.
+
+\(fn &optional OPT-COMMAND-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/gub/gub" '("realgud:gub-command-name" "realgud-gub-fn" "gub")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/gub/init" "realgud/debugger/gub/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/gub/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/gub/init" '("realgud:gub-frame-" "realgud:gub-command-hash" "realgud:gub-selected-frame-arrow" "realgud:gub-pat-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/gub/track-mode" "realgud/debugger/gub/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/gub/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/gub/track-mode" '("realgud:gub-goto-panic-location" "realgud:gub-goto-location" "gub-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/ipdb/core" "realgud/debugger/ipdb/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/ipdb/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/ipdb/core" '("realgud:ipdb-" "ipdb-parse-" "ipdb-reset" "ipdb-suggest-invocation" "ipdb-query-cmdline")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/ipdb/init" "realgud/debugger/ipdb/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/ipdb/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/ipdb/init" '("realgud:ipdb-pat-hash" "realgud:ipdb-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/ipdb/ipdb" "realgud/debugger/ipdb/ipdb.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/ipdb/ipdb.el
+
+(autoload 'realgud:ipdb "realgud/debugger/ipdb/ipdb" "\
+Invoke the ipdb Python debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run ipdb. You will be prompted
+for a command line is one isn't supplied.
+
+OPT-COMMAND-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `ipdb-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(autoload 'realgud:ipdb-remote "realgud/debugger/ipdb/ipdb" "\
+Invoke the ipdb Python debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run ipdb. You will be prompted
+for a command line is one isn't supplied.
+
+OPT-COMMAND-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `ipdb-parse-remote-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/ipdb/ipdb" '("realgud:ipdb-command-name" "ipdb")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/ipdb/track-mode" "realgud/debugger/ipdb/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/ipdb/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/ipdb/track-mode" '("ipdb-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/jdb/backtrack-mode" "realgud/debugger/jdb/backtrack-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/jdb/backtrack-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/jdb/backtrack-mode" '("realgud:jdb-goto-control-frame-line" "jdb-backtrack-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/jdb/core" "realgud/debugger/jdb/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/jdb/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/jdb/core" '("realgud:jdb-" "jdb-reset" "jdb-suggest-invocation")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/jdb/file" "realgud/debugger/jdb/file.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/jdb/file.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/jdb/file" '("gud-jdb-")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/jdb/init" "realgud/debugger/jdb/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/jdb/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/jdb/init" '("realgud:jdb-")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/jdb/jdb" "realgud/debugger/jdb/jdb.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/jdb/jdb.el
+
+(autoload 'realgud:jdb "realgud/debugger/jdb/jdb" "\
+Invoke the Java jdb debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `jdb-parse-cmd-args' and path elements found by that
+are expanded using `expand-file-name'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/jdb/jdb" '("realgud:jdb-command-name" "jdb")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/jdb/track-mode" "realgud/debugger/jdb/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/jdb/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/jdb/track-mode" '("realgud:jdb-track-mode" "realgud:jdb-goto-control-frame-line" "realgud:jdb-goto-syntax-error-line")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/kshdb/core" "realgud/debugger/kshdb/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/kshdb/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/kshdb/core" '("realgud:kshdb-" "kshdb-query-cmdline" "kshdb-parse-cmd-args" "kshdb-suggest-invocation" "kshdb-reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/kshdb/init" "realgud/debugger/kshdb/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/kshdb/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/kshdb/init" '("realgud:kshdb-pat-hash" "realgud:kshdb-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/kshdb/kshdb" "realgud/debugger/kshdb/kshdb.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/kshdb/kshdb.el
+
+(autoload 'realgud:kshdb "realgud/debugger/kshdb/kshdb" "\
+Invoke the Korn shell debugger, kshdb, and start the Emacs user interface.
+
+String COMMAND-LINE specifies how to run kshdb.
+
+Normally command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset.
+
+\(fn &optional OPT-COMMAND-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/kshdb/kshdb" '("realgud:kshdb-command-name" "kshdb")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/kshdb/track-mode" "realgud/debugger/kshdb/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/kshdb/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/kshdb/track-mode" '("kshdb-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/nodejs/core" "realgud/debugger/nodejs/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/nodejs/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/nodejs/core" '("realgud:nodejs-" "nodejs-query-cmdline" "nodejs-parse-cmd-args")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/nodejs/init" "realgud/debugger/nodejs/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/nodejs/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/nodejs/init" '("realgud:nodejs-frame-" "realgud:nodejs-pat-hash" "realgud:nodejs-debugger-name" "realgud:nodejs-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/nodejs/nodejs" "realgud/debugger/nodejs/nodejs.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/nodejs/nodejs.el
+
+(autoload 'realgud:nodejs "realgud/debugger/nodejs/nodejs" "\
+Invoke the nodejs shell debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run nodejs.
+
+OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `nodejs-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/nodejs/nodejs" '("realgud:nodejs-command-name")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/nodejs/track-mode" "realgud/debugger/nodejs/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/nodejs/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/nodejs/track-mode" '("realgud:nodejs-track-mode-internal" "nodejs-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/pdb/core" "realgud/debugger/pdb/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/pdb/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/pdb/core" '("realgud:pdb-" "pdb-parse-" "pdb-reset" "pdb-suggest-invocation" "pdb-query-cmdline")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/pdb/init" "realgud/debugger/pdb/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/pdb/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/pdb/init" '("realgud:pdb-pat-hash" "realgud:pdb-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/pdb/pdb" "realgud/debugger/pdb/pdb.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/pdb/pdb.el
+
+(autoload 'realgud:pdb "realgud/debugger/pdb/pdb" "\
+Invoke the pdb Python debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run pdb. You will be prompted
+for a command line is one isn't supplied.
+
+OPT-COMMAND-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `pdb-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(autoload 'realgud:pdb-remote "realgud/debugger/pdb/pdb" "\
+Invoke the pdb Python debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run pdb. You will be prompted
+for a command line is one isn't supplied.
+
+OPT-COMMAND-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `pdb-parse-remote-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/pdb/pdb" '("realgud:pdb-command-name" "pdb")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/pdb/track-mode" "realgud/debugger/pdb/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/pdb/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/pdb/track-mode" '("pdb-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/perldb/core" "realgud/debugger/perldb/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/perldb/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/perldb/core" '("realgud:perldb-")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/perldb/init" "realgud/debugger/perldb/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/perldb/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/perldb/init" '("realgud:perldb-loc-regexp" "realgud:perldb-loc-noeval-regexp" "realgud:perldb-loc-eval-regexp" "realgud:perldb-command-hash" "realgud:perldb-pat-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/perldb/perldb" "realgud/debugger/perldb/perldb.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/perldb/perldb.el
+
+(autoload 'realgud:perldb "realgud/debugger/perldb/perldb" "\
+Invoke the Perl debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run nodejs.
+
+OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `perldb-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/perldb/perldb" '("realgud:perldb-command-name")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/perldb/track-mode" "realgud/debugger/perldb/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/perldb/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/perldb/track-mode" '("perldb-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/rdebug/core" "realgud/debugger/rdebug/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/rdebug/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/rdebug/core" '("realgud:rdebug-" "rdebug-query-cmdline" "rdebug-parse-cmd-args" "rdebug-suggest-invocation" "rdebug-reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/rdebug/init" "realgud/debugger/rdebug/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/rdebug/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/rdebug/init" '("realgud-rdebug-pat-hash" "realgud-rdebug-command-hash" "realgud-rdebug-frame-file-line-regexp" "realgud-rdebug-frame-start-regexp" "realgud-rdebug-frame-num-regexp")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/rdebug/rdebug" "realgud/debugger/rdebug/rdebug.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/rdebug/rdebug.el
+
+(autoload 'realgud:rdebug "realgud/debugger/rdebug/rdebug" "\
+Invoke the rdebug Ruby debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `trepan8-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/rdebug/rdebug" '("realgud:rdebug-command-name" "rdebug-get-script-name" "rdebug")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/rdebug/track-mode" "realgud/debugger/rdebug/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/rdebug/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/rdebug/track-mode" '("rdebug-track-mode" "rdebug-track-mode-internal")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/remake/core" "realgud/debugger/remake/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/remake/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/remake/core" '("realgud:remake-" "remake-suggest-" "remake-query-cmdline" "remake-parse-cmd-args" "remake-reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/remake/init" "realgud/debugger/remake/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/remake/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/remake/init" '("realgud:remake-frame-" "realgud:remake-command-hash" "realgud:remake-selected-frame-arrow" "realgud:remake-pat-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/remake/remake" "realgud/debugger/remake/remake.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/remake/remake.el
+
+(autoload 'realgud:remake "realgud/debugger/remake/remake" "\
+See `realgud:remake' for details
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/remake/remake" '("realgud:remake-run-debugger" "realgud:remake-command-name" "remake")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/remake/track-mode" "realgud/debugger/remake/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/remake/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/remake/track-mode" '("remake-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan.pl/backtrack-mode"
+;;;;;;  "realgud/debugger/trepan.pl/backtrack-mode.el" (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan.pl/backtrack-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan.pl/backtrack-mode" '("realgud:trepanpl-goto-control-frame-line" "trepanpl-backtrack-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan.pl/core" "realgud/debugger/trepan.pl/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan.pl/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan.pl/core" '("realgud:trepanpl-")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan.pl/init" "realgud/debugger/trepan.pl/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan.pl/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan.pl/init" '("realgud:trepanpl-")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan.pl/track-mode" "realgud/debugger/trepan.pl/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan.pl/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan.pl/track-mode" '("realgud:trepanpl-goto-syntax-error-line" "realgud:trepanpl-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan.pl/trepanpl" "realgud/debugger/trepan.pl/trepanpl.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan.pl/trepanpl.el
+
+(autoload 'realgud:trepan\.pl "realgud/debugger/trepan.pl/trepanpl" "\
+Invoke the trepan.pl Perl debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run trepan.pl. You will be prompted
+for a command line is one isn't supplied.
+
+OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `realgud:trepanpl-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan.pl/trepanpl" '("realgud:trepanpl-command-name" "trepan.pl")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan/backtrack-mode" "realgud/debugger/trepan/backtrack-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan/backtrack-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan/backtrack-mode" '("realgud:trepan-goto-control-frame-line" "trepan-backtrack-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan/core" "realgud/debugger/trepan/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan/core" '("realgud:trepan-" "trepan-reset" "trepan-suggest-invocation")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan/init" "realgud/debugger/trepan/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan/init" '("realgud:trepan-command-hash" "realgud:trepan-debugger-name" "realgud:trepan-frame-file-regexp" "realgud:trepan-selected-frame-indicator" "realgud:trepan-pat-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan/track-mode" "realgud/debugger/trepan/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan/track-mode" '("trepan-track-mode" "realgud:trepan-goto-control-frame-line" "realgud:trepan-goto-syntax-error-line")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan/trepan" "realgud/debugger/trepan/trepan.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan/trepan.el
+
+(autoload 'realgud:trepan "realgud/debugger/trepan/trepan" "\
+Invoke the trepan Ruby debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `trepan-parse-cmd-args' and path elements found by that
+are expanded using `expand-file-name'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan/trepan" '("realgud:trepan-command-name" "trepan")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan2/core" "realgud/debugger/trepan2/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan2/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan2/core" '("realgud:trepan2-" "trepan2-query-cmdline" "trepan2-parse-cmd-args" "trepan2-suggest-invocation" "trepan2-reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan2/init" "realgud/debugger/trepan2/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan2/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan2/init" '("realgud:trepan2-pat-hash" "realgud:trepan2-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan2/track-mode" "realgud/debugger/trepan2/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan2/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan2/track-mode" '("trepan2-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan2/trepan2" "realgud/debugger/trepan2/trepan2.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan2/trepan2.el
+
+(autoload 'realgud:trepan2 "realgud/debugger/trepan2/trepan2" "\
+Invoke the trepan2 Python debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `trepan2-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan2/trepan2" '("realgud:trepan2-command-name" "trepan2")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan3k/core" "realgud/debugger/trepan3k/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan3k/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan3k/core" '("realgud:trepan3k-" "trepan3k-query-cmdline" "trepan3k-parse-cmd-args" "trepan3k-suggest-invocation" "trepan3k-reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan3k/init" "realgud/debugger/trepan3k/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan3k/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan3k/init" '("realgud:trepan3k-pat-hash" "realgud:trepan3k-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan3k/track-mode" "realgud/debugger/trepan3k/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan3k/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan3k/track-mode" '("trepan3k-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepan3k/trepan3k" "realgud/debugger/trepan3k/trepan3k.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepan3k/trepan3k.el
+
+(autoload 'realgud:trepan3k "realgud/debugger/trepan3k/trepan3k" "\
+Invoke the trepan3k Python debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `trepan2-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepan3k/trepan3k" '("realgud:trepan3k-command-name" "trepan3k")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepanjs/backtrack-mode"
+;;;;;;  "realgud/debugger/trepanjs/backtrack-mode.el" (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepanjs/backtrack-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepanjs/backtrack-mode" '("realgud:trepanjs-goto-control-frame-line" "trepanjs-backtrack-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepanjs/core" "realgud/debugger/trepanjs/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepanjs/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepanjs/core" '("realgud:trepanjs-")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepanjs/init" "realgud/debugger/trepanjs/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepanjs/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepanjs/init" '("realgud:trepanjs-frame-" "realgud:trepanjs-pat-hash" "realgud:trepanjs-file-regexp" "realgud:trepanjs-debugger-name" "realgud:trepanjs-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepanjs/track-mode" "realgud/debugger/trepanjs/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepanjs/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepanjs/track-mode" '("realgud:trepanjs-goto-syntax-error-line" "trepanjs-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/trepanjs/trepanjs" "realgud/debugger/trepanjs/trepanjs.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/trepanjs/trepanjs.el
+
+(autoload 'realgud:trepanjs "realgud/debugger/trepanjs/trepanjs" "\
+Invoke the trepanjs Ruby debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `trepanjs-parse-cmd-args' and path elements found by that
+are expanded using `expand-file-name'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/trepanjs/trepanjs" '("realgud:trepanjs-command-name" "trepanjs")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/zshdb/core" "realgud/debugger/zshdb/core.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/zshdb/core.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/zshdb/core" '("realgud:zshdb-" "zshdb-query-cmdline" "zshdb-parse-cmd-args" "zshdb-suggest-invocation" "zshdb-reset")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/zshdb/init" "realgud/debugger/zshdb/init.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/zshdb/init.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/zshdb/init" '("realgud:zshdb-pat-hash" "realgud:zshdb-command-hash")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/zshdb/track-mode" "realgud/debugger/zshdb/track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/zshdb/track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/zshdb/track-mode" '("zshdb-track-mode")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/debugger/zshdb/zshdb" "realgud/debugger/zshdb/zshdb.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/debugger/zshdb/zshdb.el
+
+(autoload 'realgud:zshdb "realgud/debugger/zshdb/zshdb" "\
+Invoke the zshdb Z-shell debugger and start the Emacs user interface.
+
+String OPT-CMD-LINE specifies how to run zshdb.
+
+OPT-CMD-LINE is treated like a shell string; arguments are
+tokenized by `split-string-and-unquote'. The tokenized string is
+parsed by `zshdb-parse-cmd-args' and path elements found by that
+are expanded using `realgud:expand-file-name-if-exists'.
+
+Normally, command buffers are reused when the same debugger is
+reinvoked inside a command buffer with a similar command. If we
+discover that the buffer has prior command-buffer information and
+NO-RESET is nil, then that information which may point into other
+buffers and source buffers which may contain marks and fringe or
+marginal icons is reset. See `loc-changes-clear-buffer' to clear
+fringe and marginal icons.
+
+\(fn &optional OPT-CMD-LINE NO-RESET)" t nil)
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/debugger/zshdb/zshdb" '("realgud:zshdb-command-name" "zshdb")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/lang/js" "realgud/lang/js.el" (0 0
+;;;;;;  0 0))
+;;; Generated autoloads from realgud/lang/js.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/lang/js" '("realgud:js-backtrace-loc-pat" "realgud:js-term-escape")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/lang/perl" "realgud/lang/perl.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/lang/perl.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/lang/perl" '("realgud:perl-goto-errmsg-line" "realgud-perl-populate-command-keys" "realgud-perl-ignore-file-re" "realgud-perl-errmsg-loc-pat" "realgud-perl-carp-loc-pat")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/lang/posix-shell" "realgud/lang/posix-shell.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/lang/posix-shell.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/lang/posix-shell" '("realgud-shell-frame-" "realgud:POSIX-debugger-" "realgud-shell-backtrace-loc-pat" "realgud-posix-shell-populate-command-keys")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/lang/python" "realgud/lang/python.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/lang/python.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/lang/python" '("realgud:python-trepan-" "realgud-python-" "realgud:python-debugger-font-lock-keywords" "realgud-pytest-error-loc-pat" "realgud:pytest-goto-errmsg-line")))
+
+;;;***
+
+;;;### (autoloads nil "realgud/lang/ruby" "realgud/lang/ruby.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from realgud/lang/ruby.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "realgud/lang/ruby" '("realgud:" "realgud-ruby-" "realgud-rubinius-" "realgud-rspec-backtrace-loc-pat" "realgud-rails-backtrace-loc-pat")))
+
+;;;***
+
+;;;### (autoloads nil "test/test-common-helper" "test/test-common-helper.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from test/test-common-helper.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "test/test-common-helper" '("realgud-test-info")))
+
+;;;***
+
+;;;### (autoloads nil "test/test-gdb" "test/test-gdb.el" (0 0 0 0))
+;;; Generated autoloads from test/test-gdb.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "test/test-gdb" '("realgud:gdb-executable")))
+
+;;;***
+
+;;;### (autoloads nil "test/test-remake" "test/test-remake.el" (0
+;;;;;;  0 0 0))
+;;; Generated autoloads from test/test-remake.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "test/test-remake" '("realgud-exec-shell")))
+
+;;;***
+
+;;;### (autoloads nil "test/test-send" "test/test-send.el" (0 0 0
+;;;;;;  0))
+;;; Generated autoloads from test/test-send.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "test/test-send" '("setup")))
+
+;;;***
+
+;;;### (autoloads nil "test/test-srcbuf" "test/test-srcbuf.el" (0
+;;;;;;  0 0 0))
+;;; Generated autoloads from test/test-srcbuf.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "test/test-srcbuf" '("temp-cmdbuf" "setup")))
+
+;;;***
+
+;;;### (autoloads nil "test/test-track-mode" "test/test-track-mode.el"
+;;;;;;  (0 0 0 0))
+;;; Generated autoloads from test/test-track-mode.el
+
+(if (fboundp 'register-definition-prefixes) (register-definition-prefixes "test/test-track-mode" '("temp-cmdbuf" "setup")))
+
+;;;***
+
+;;;### (autoloads nil nil ("realgud/common/attach.el" "realgud/common/follow.el"
+;;;;;;  "test/bt-helper.el" "test/regexp-helper.el" "test/test-bashdb.el"
+;;;;;;  "test/test-bp.el" "test/test-bt-pdb.el" "test/test-bt-rdebug.el"
+;;;;;;  "test/test-bt-trepan.el" "test/test-bt-trepan2.el" "test/test-bt-trepan3k.el"
+;;;;;;  "test/test-bt-zshdb.el" "test/test-buf-bt.el" "test/test-buf-cmd.el"
+;;;;;;  "test/test-core.el" "test/test-file.el" "test/test-gdb-core.el"
+;;;;;;  "test/test-gub-core.el" "test/test-ipdb.el" "test/test-jdb.el"
+;;;;;;  "test/test-lang.el" "test/test-loc-regexp-gub.el" "test/test-loc-regexp-nodejs.el"
+;;;;;;  "test/test-loc-regexp-trepan.el" "test/test-loc-regexp-trepanpl.el"
+;;;;;;  "test/test-loc.el" "test/test-lochist.el" "test/test-nodejs.el"
+;;;;;;  "test/test-pdb.el" "test/test-perldb.el" "test/test-rdebug.el"
+;;;;;;  "test/test-realgud.el" "test/test-regexp-bashdb.el" "test/test-regexp-gdb.el"
+;;;;;;  "test/test-regexp-gub.el" "test/test-regexp-ipdb.el" "test/test-regexp-jdb.el"
+;;;;;;  "test/test-regexp-nodejs.el" "test/test-regexp-pdb.el" "test/test-regexp-perldb.el"
+;;;;;;  "test/test-regexp-rdebug.el" "test/test-regexp-remake.el"
+;;;;;;  "test/test-regexp-ruby.el" "test/test-regexp-trepan.el" "test/test-regexp-trepan2.el"
+;;;;;;  "test/test-regexp-trepan3k.el" "test/test-regexp-trepanjs.el"
+;;;;;;  "test/test-regexp-trepanpl.el" "test/test-regexp-zshdb.el"
+;;;;;;  "test/test-regexp.el" "test/test-remake-core.el" "test/test-shortkey.el"
+;;;;;;  "test/test-track.el" "test/test-trepan2.el" "test/test-trepan3k.el"
+;;;;;;  "test/test-trepanpl.el" "test/test-utils.el" "test/test-zshdb.el")
+;;;;;;  (0 0 0 0))
+
+;;;***
+
+(provide 'realgud-recursive-autoloads)
+;; Local Variables:
+;; version-control: never
+;; no-byte-compile: t
+;; no-update-autoloads: t
+;; coding: utf-8
+;; End:
+;;; realgud-recursive-autoloads.el ends here

--- a/realgud.el
+++ b/realgud.el
@@ -198,6 +198,48 @@ development version and you already have this package loaded."
 ;; Load everything.
 (realgud:load-features)
 
+
+;;; Autoloads-related code
+
+;; This section is needed because package.el doesn't recurse into subdirectories
+;; when looking for autoload-able forms.  As a workaround, we statically
+;; generate our own autoloads, and force Emacs to read them by adding an extra
+;; autoloded form.
+
+;;;###autoload
+(defconst realgud--recursive-autoloads-file-name "realgud-recursive-autoloads.el"
+  "Where to store autoloads for subdirectory contents.")
+
+;;;###autoload
+(defconst realgud--recursive-autoloads-base-directory
+  (file-name-directory
+   (if load-in-progress load-file-name
+     buffer-file-name)))
+
+;;;###autoload
+(with-demoted-errors "Error in RealGUD's autoloads: %s"
+  (load (expand-file-name realgud--recursive-autoloads-file-name
+                          realgud--recursive-autoloads-base-directory)
+        t t))
+
+(defun realgud--rebuild-recursive-autoloads ()
+  "Update RealGUD's recursive autoloads.
+This is needed because the package.el infrastructure doesn't
+process autoloads in subdirectories; instead we create an
+additional autoloads file of our own, and we load it from an
+autoloaded form.  Maintainers should run this after adding
+autoloaded functions, and commit the resulting changes."
+  (interactive)
+  (let ((generated-autoload-file
+         (expand-file-name realgud--recursive-autoloads-file-name
+                           realgud--recursive-autoloads-base-directory)))
+    (when (file-exists-p generated-autoload-file)
+      (delete-file generated-autoload-file))
+    (dolist (name (directory-files-recursively
+                   realgud--recursive-autoloads-base-directory "" t))
+      (when (file-directory-p name)
+        (update-directory-autoloads name)))))
+
 (provide-me)
 
 ;;; realgud.el ends here


### PR DESCRIPTION
Fixes #84; the discussion on emacs-dev concluded that this was the best solution. The commit is annoyingly large, but the only actual changes are in `realgud.el`.

After merging this, we'll need to update the MELPA recipe to include this file autoloads file. We could probably simplify it, too, so that future additions don't require additional changes.

This also adds a small maintenance burden: when we add new autoloads, we'll need to run `realgud--rebuild-recursive-autoloads`. This seems like an acceptable trade-off.

What do you think?