### PR TITLE
Refactor and improve breakpoint UI

### DIFF
--- a/realgud/common/cmds.el
+++ b/realgud/common/cmds.el
@@ -173,6 +173,25 @@ be found on the current line, prompt for a breakpoint number."
     (interactive (realgud:bpnum-from-prefix-arg))
     (realgud:cmd-run-command bpnum "enable" "enable %p"))
 
+(defun realgud-cmds--add-remove-bp (pos)
+  "Add or delete breakpoint at POS."
+  (save-excursion
+    (goto-char pos)
+    (let ((existing-bp-num (realgud:bpnum-on-current-line)))
+      (if existing-bp-num
+          (realgud:cmd-delete existing-bp-num)
+        (realgud:cmd-break pos)))))
+
+(defun realgud-cmds--mouse-add-remove-bp (event)
+  "Add or delete breakpoint on line pointed to by EVENT.
+EVENT should be a mouse click on the left fringe or margin."
+  (interactive "e")
+  (let* ((posn (event-end event))
+         (pos (posn-point posn)))
+    (when (numberp pos)
+      (with-current-buffer (window-buffer (posn-window posn))
+        (realgud-cmds--add-remove-bp pos)))))
+
 (defun realgud:cmd-eval(arg)
     "Evaluate an expression."
     (interactive "MEval expesssion: ")

--- a/realgud/common/fringe-utils.py
+++ b/realgud/common/fringe-utils.py
@@ -1,0 +1,36 @@
+def bit2char(byte, offset):
+    return "X" if byte & (1 << offset) else " "
+
+def char2bit(char, offset):
+    return (0 if char == " " else 1) << offset
+
+def decompile_bitmap(bmp_bytes):
+    lines = []
+    for b in bmp_bytes:
+        lines.append("".join(bit2char(b, offset) for offset in range(8)))
+    return lines
+
+def compile_bitmap(bmp_lines):
+    bmp_bytes = []
+    for line in bmp_lines:
+        s = sum(char2bit(c, offset) for (offset, c) in enumerate(line))
+        print(s)
+        bmp_bytes.append(s.to_bytes(1, byteorder="big"))
+    return b"".join(bmp_bytes)
+
+hollow_circle = ["  XXXX  ",
+                 " X    X ",
+                 "X      X",
+                 "X      X",
+                 "X      X",
+                 "X      X",
+                 " X    X ",
+                 "  XXXX  "]
+
+def print_compiled(bmp):
+    print("".join(r'\x{:02x}'.format(b) for b in bmp))
+
+print("\n".join(decompile_bitmap(b"\x3c\x7e\xff\xff\xff\xff\x7e\x3c")))
+print_compiled(compile_bitmap(decompile_bitmap(b"\x3c\x7e\xff\xff\xff\xff\x7e\x3c")))
+print_compiled(compile_bitmap(hollow_circle))
+

--- a/realgud/common/shortkey.el
+++ b/realgud/common/shortkey.el
@@ -46,6 +46,8 @@
     (define-key map "e"        'realgud:cmd-eval-dwim)
     (define-key map "U"        'realgud:cmd-until)
     (define-key map [mouse-2]  'realgud:tooltip-eval)
+    (define-key map [left-fringe mouse-1] #'realgud-cmds--mouse-add-remove-bp)
+    (define-key map [left-margin mouse-1] #'realgud-cmds--mouse-add-remove-bp)
 
     ;; FIXME: these can go to a common routine
     (define-key map "<"        'realgud:cmd-newer-frame)


### PR DESCRIPTION
Improvements:

* Properly handle multiple breakpoints on the same line
* Use fringes instead of margins to display breakpoint icons on
  graphical displays (customizable with realgud-bp-use-fringe)
* Let users set or disable breakpoints by clicking on the fringe or
  in the margin
* Make breakpoint fringe icons customizable, and default to a hollow
  circle for disabled breakpoints

Some notes: I kept the structure of the code mostly unchanged, though I did quite a bit of refactoring. Among the things that changed is the fact that I now add properties to the breakpoint overlays, including the breakpoint number. This has two nice advantages: removing overlays is easier, and we can be more precise when removing; in particular, adding multiple breakpoints on the same line and removing them one by one now leaves a breakpoint indicator on the line until they are all removed (previously removing the first breakpoint would hide the indicator, though there were still breakpoints on that line).

I'd love some help with testing, though things seem to work quite ok on my machine at least :) Question: did any code depend on the particular structure of the before-strings (e.g. `B18: ...`)?