### PR TITLE
Automatically attach to a command buffer when enabling short-key-mode

### DIFF
--- a/realgud/common/buffer/source.el
+++ b/realgud/common/buffer/source.el
@@ -1,11 +1,11 @@
 ;;; Copyright (C) 2010, 2012-2015 Rocky Bernstein <rocky@gnu.org>
 ;;; source-code buffer code
 (eval-when-compile
-  (require 'cl-lib)
   (defvar realgud-srcbuf-info) ;; is buffer local
   (defvar realgud-cmdbuf-info) ;; in the cmdbuf, this is buffer local
   )
 
+(require 'cl-lib)
 (require 'load-relative)
 (require-relative-list '("../helper" "../key") "realgud-")
 
@@ -38,6 +38,7 @@ to be debugged."
 		 ;; variable. Short-key-mode may change the read-only
 		 ;; state, so we need restore this value when leaving
 		 ;; short-key mode
+  prev-local-map ;; Local map before enabling short-key-mode
 
   loc-hist       ;; ring of locations seen
 
@@ -54,6 +55,7 @@ to be debugged."
 (realgud-struct-field-setter "realgud-srcbuf-info" "cmdproc")
 (realgud-struct-field-setter "realgud-srcbuf-info" "short-key?")
 (realgud-struct-field-setter "realgud-srcbuf-info" "was-read-only?")
+(realgud-struct-field-setter "realgud-srcbuf-info" "prev-local-map")
 
 (defun realgud-srcbuf-info-set? ()
   "Return true if `realgud-srcbuf-info' is set."
@@ -67,6 +69,30 @@ to be debugged."
     (and (realgud-srcbuf-info-set?)
 	 (not (buffer-killed? (realgud-sget 'srcbuf-info 'cmdproc)))
    )))
+
+(defun realgud--read-cmd-buf (prompt)
+  "Read a command buffer, prompting with PROMPT."
+  (let* ((cmd-bufs (cl-remove-if-not #'realgud-cmdbuf? (buffer-list)))
+         (cmd-buf-names (mapcar #'buffer-name cmd-bufs)))
+    (when cmd-buf-names
+      ;; Use completing-read instead of read-buffer: annoyingly, ido's
+      ;; read-buffer ignores predicates.
+      (get-buffer (completing-read prompt cmd-buf-names nil t
+                                   nil nil (car cmd-buf-names))))))
+
+(defun realgud--ensure-attached (&optional src-buf)
+  "Try to attach SRC-BUF to a command buffer.
+If SRC-BUF is already attached, do nothing.  Otherwise, prompt
+the user for a command buffer to associate SRC-BUF to.  Returns
+non-nil if association was successful.  SRC-BUF defaults to
+current buffer."
+  (setq src-buf (or src-buf (current-buffer)))
+  (unless (realgud-srcbuf? src-buf)
+    (let ((cmd-buf (realgud--read-cmd-buf "Command buffer to associate to: ")))
+      (if cmd-buf
+          (realgud-srcbuf-init src-buf cmd-buf)
+        (message "No debugger process found to attach %s to" (buffer-name)))))
+  (realgud-srcbuf? src-buf))
 
 (defun realgud-srcbuf-debugger-name (&optional src-buf)
   "Return the debugger name recorded in the debugger command-process buffer."

--- a/realgud/common/shortkey.el
+++ b/realgud/common/shortkey.el
@@ -22,6 +22,7 @@
 (declare-function realgud-populate-src-buffer-map-plain 'realgud-key)
 (declare-function realgud-srcbuf-info-short-key?=,      'realgud-source)
 (declare-function realgud-srcbuf-info-was-read-only?=   'realgud-source)
+(declare-function realgud-srcbuf-info-prev-local-map=   'realgud-source)
 (declare-function realgud-srcbuf?                       'realgud-buffer-source)
 
 ;; (defvar realgud::tool-bar-map) ;; fully defined in track-mode.el
@@ -102,58 +103,39 @@ The buffer is read-only when the minor mode is active.
     ))
 
 (defun realgud-short-key-mode-setup (mode-on?)
-  "Called when entering or leaving `realgud-short-key-mode'. Variable
-MODE-ON? a boolean which specifies if we are going into or out of this mode."
-  (if (realgud-srcbuf?)
-    (let* ((cmdbuf (realgud-get-cmdbuf))
-	   (shortkey-keymap (realgud-get-short-key-mode-map cmdbuf))
-	   )
-
-      ;; If there's a shortkey keymap that is custom
-      ;; for this debugger mode, use it.
-      (when shortkey-keymap
-	(cond
-	 (mode-on?
-	  (set (make-local-variable 'tool-bar-map) realgud:tool-bar-map)
-	  (use-local-map shortkey-keymap))
-	 ('t
-	  (kill-local-variable 'realgud:tool-bar-map)
-	  (use-local-map nil))
-	  ))
-
-      ;; Ensure action only is performed when the state actually is toggled.
-      ;; or when not read-only
-      (when (or (not buffer-read-only)
-		(not (eq (realgud-sget 'srcbuf-info 'short-key?) mode-on?)))
-	;; Save the current state, so we can determine when the
-	;; state is toggled in the future.
-	(when (not (eq (realgud-sget 'srcbuf-info 'short-key?) mode-on?))
-	  (realgud-srcbuf-info-short-key?= mode-on?)
-	  (setq realgud-short-key-mode mode-on?)
-	  (if mode-on?
-	      ;; mode is being turned on.
-	      (progn
-		(realgud-srcbuf-info-was-read-only?= buffer-read-only)
-
-		;; If there's a shortkey keymap that is custom
-		;; for this debugger mode, use it.
-		(if shortkey-keymap (use-local-map shortkey-keymap))
-
-		(local-set-key [m-insert] 'realgud-short-key-mode)
-		(when realgud-srcbuf-lock (setq buffer-read-only t))
-		(run-mode-hooks 'realgud-short-key-mode-hook))
-	    ;; mode is being turned off: restore read-only state.
-	    (setq buffer-read-only
-		  (realgud-sget 'srcbuf-info 'was-read-only?))))
-    ;; (with-current-buffer-safe cmdbuf
-    ;;   (realgud-cmdbuf-info-src-shortkey?= mode-on?)
-    ;;   (realgud-cmdbuf-info-in-srcbuf?= mode-on?)
-    ;;   )
-    ))
-    (progn
-      (setq realgud-short-key-mode nil)
-      (error "buffer %s does not seem to be attached to a debugger"
-	   (buffer-name)))))
+  "Set up or tear down `realgud-short-key-mode'.
+MODE-ON? is a boolean indicating whether the mode should be
+turned on or off."
+  (setq realgud-short-key-mode mode-on?)
+  ;; When enabling, try to find a command buffer to attach to.
+  (when (and realgud-short-key-mode (not (realgud--ensure-attached)))
+    (setq realgud-short-key-mode nil))
+  ;; Now apply mode change
+  (cond
+   ;; Mode was just enabled
+   (realgud-short-key-mode
+    ;; Record info to restore it when disabling
+    (unless (equal (realgud-sget 'srcbuf-info 'short-key?) realgud-short-key-mode)
+      (realgud-srcbuf-info-prev-local-map= (current-local-map))
+      (realgud-srcbuf-info-was-read-only?= buffer-read-only))
+    ;; Apply local map
+    (let ((keymap (realgud-get-short-key-mode-map (realgud-get-cmdbuf))))
+      (when keymap (use-local-map keymap)))
+    ;; Finish setting up
+    (set (make-local-variable 'tool-bar-map) realgud:tool-bar-map)
+    (local-set-key [m-insert] #'realgud-short-key-mode)
+    (setq buffer-read-only realgud-srcbuf-lock)
+    (run-mode-hooks 'realgud-short-key-mode-hook))
+   ;; Mode was just disabled
+   (t
+    (kill-local-variable 'tool-bar-map)
+    (when (realgud-srcbuf-info-set?)
+      ;; Restore previous state
+      (use-local-map (realgud-sget 'srcbuf-info 'prev-local-map))
+      (setq buffer-read-only (realgud-sget 'srcbuf-info 'was-read-only?)))))
+  ;; Record state
+  (when (realgud-srcbuf-info-set?)
+    (realgud-srcbuf-info-short-key?= realgud-short-key-mode)))
 
 (defun realgud-short-key-mode-off ()
   "Turn off `realgud-short-key-mode' in all buffers."


### PR DESCRIPTION
When enabling short-key-mode in an orphan source buffer (i.e. one that
isn't attached to a command buffer), prompt the user for a command
buffer to attach to instead of complaining (and complain only if there
is no available command buffer).

Additionally make shortkey-mode-setup more robust by restoring the
original local map properly disabling the toolbar after exiting.

Closes #36; thanks for the suggestion!